### PR TITLE
dev: introduce Nix-based development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+watch_file nix/flake.nix
+watch_file nix/flake.lock
+use flake ./nix

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ dist/*
 node_modules/*
 .vscode/*
 .env.development
+
+result*
+.direnv/

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722073938,
+        "narHash": "sha256-OpX0StkL8vpXyWOGUD6G+MA26wAXK6SpT94kLJXo6B4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e36e9f57337d0ff0cf77aceb58af4c805472bfae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1750506804,
+        "narHash": "sha256-VLFNc4egNjovYVxDGyBYTrvVCgDYgENp5bVi9fPTDYc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4206c4cb56751df534751b058295ea61357bbbaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "AListen UI";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    devshell.url = "github:numtide/devshell";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        inputs.devshell.flakeModule
+      ];
+
+      perSystem = { pkgs, ... }: {
+        devshells.default = {
+          packages = with pkgs; [
+            nodejs
+            pnpm
+            typescript
+            nodePackages.typescript-language-server
+            vscode-langservers-extracted
+            vue-language-server
+            efm-langserver
+          ];
+        };
+      };
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+    };
+}


### PR DESCRIPTION
## Add Nix Flake for Development Environment

This PR introduces a Nix-based development environment for the project, making it easier to get started with consistent tooling across different systems.

### Changes Included:

1. **Added Nix flake configuration** (`nix/flake.nix`):
   - Sets up a devshell with all required JS/Vue tooling:
     - Node.js, pnpm, TypeScript
     - Language servers (TS, Vue, ESLint)
   - Supports multiple architectures (x86_64/aarch64, Linux/Darwin)

2. **Added direnv integration** (`.envrc`):
   - Automatically loads the Nix environment when entering the project directory
   - Watches for changes to flake files

3. **Updated `.gitignore`**:
   - Added patterns for Nix build results (`result*`)
   - Added direnv directory (`.direnv/`)

### Benefits:
- 🚀 **Quick setup** - Just run `nix develop` or let direnv handle it automatically
- 🔄 **Reproducible** - Same versions of tools for all developers
- 🖥️ **Multi-platform** - Works on both Linux and macOS (Intel/Apple Silicon)

### How to Use:
1. Install Nix and direnv (if not already installed)
2. Run `direnv allow` in the project root
3. The development environment will load automatically