### PR TITLE
feat: 添加播放列表歌曲网页跳转功能

### DIFF
--- a/src/components/PlaylistItem.vue
+++ b/src/components/PlaylistItem.vue
@@ -1,13 +1,16 @@
 <template>
   <div
-    class="playlist-item transition-all cursor-pointer"
+    class="playlist-item transition-all"
     :class="[
       {
         'bg-primary/20 hover:bg-primary/25 border-l-4 border-primary': isCurrent,
         'hover:bg-white/5': !isCurrent,
+        'cursor-pointer': song.webUrl,
+        'cursor-default': !song.webUrl,
       },
       isDesktop ? 'p-3 flex items-center' : 'p-4 flex items-center active:bg-white/10 border-b border-white/5',
     ]"
+    @click="handleSongClick"
   >
     <!-- 专辑封面 -->
     <div
@@ -87,7 +90,7 @@ interface Props {
   isMobile?: boolean
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   isCurrent: false,
   isDesktop: false,
   isMobile: false,
@@ -98,6 +101,13 @@ defineEmits<{
   like: []
   delete: []
 }>()
+
+// 处理歌曲点击事件
+function handleSongClick() {
+  if (props.song.webUrl) {
+    window.open(props.song.webUrl, '_blank')
+  }
+}
 </script>
 
 <style scoped>

--- a/src/composables/usePlayer.ts
+++ b/src/composables/usePlayer.ts
@@ -220,6 +220,7 @@ registerMessageHandler('pick', (message: any) => {
     .map((item: any) => ({
       id: item.id,
       url: item.url || '',
+      webUrl: item.webUrl || '',
       title: item.name,
       artist: item.artist || '未知艺术家',
       album: item.album?.name || '未知专辑',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export interface Song {
   album?: string
   cover: string
   url?: string
+  webUrl?: string
   duration: number
   requestedBy?: User
 }


### PR DESCRIPTION
- 在Song类型中添加webUrl字段支持歌曲网页链接
- 修改PlaylistItem组件支持点击跳转到歌曲网页
- 根据是否有webUrl动态调整鼠标样式
- 在新标签页中打开链接，不影响当前播放体验