### PR TITLE
feat: move music search button to playlist

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,6 +43,7 @@
           :is-immersive-mode="isImmersiveMode"
           @song-like="(index, title) => sendSongLike(index, title)"
           @song-delete="(songName: string) => sendDeleteSong(songName)"
+          @show-music-search="showMusicSearchModal = true"
         />
 
         <!-- 中间歌词区域 -->

--- a/src/components/PlaylistComponent.vue
+++ b/src/components/PlaylistComponent.vue
@@ -5,12 +5,24 @@
     class="w-72 bg-dark/60 backdrop-blur-xl border-r border-white/10 hidden md:block overflow-y-auto scrollbar-hide"
   >
     <div class="p-4 border-b border-white/10">
-      <h2 class="text-lg font-semibold flex items-center">
-        <i class="fa-solid fa-list-ul mr-2 text-primary" />播放列表
-      </h2>
-      <p class="text-xs text-gray-400 mt-1">
-        共 {{ playlist.length }} 首歌曲 · {{ formatTime(totalDuration) }}
-      </p>
+      <div class="flex justify-between items-center">
+        <div>
+          <h2 class="text-lg font-semibold flex items-center">
+            <i class="fa-solid fa-list-ul mr-2 text-primary" />播放列表
+          </h2>
+          <p class="text-xs text-gray-400 mt-1">
+            共 {{ playlist.length }} 首歌曲 · {{ formatTime(totalDuration) }}
+          </p>
+        </div>
+        <button
+          class="bg-white/10 hover:bg-white/20 active:bg-white/30 text-white rounded-full py-2 px-3 sm:px-4 flex items-center text-xs sm:text-sm transition-all touch-target ml-2"
+          @click="$emit('showMusicSearch')"
+        >
+          <i class="fa-solid fa-music mr-1 sm:mr-2" />
+          <span class="hidden sm:inline">点歌台</span>
+          <span class="sm:hidden">点歌</span>
+        </button>
+      </div>
     </div>
     <div class="playlist-container space-y-1">
       <PlaylistItem
@@ -91,6 +103,7 @@ defineEmits<{
   close: []
   songLike: [index: number, title: string]
   songDelete: [songName: string]
+  showMusicSearch: []
 }>()
 
 // 计算播放列表总时长

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -38,16 +38,6 @@
         <span class="sm:hidden">切歌</span>
       </button>
 
-      <!-- 点歌台 -->
-      <button
-        class="bg-white/10 hover:bg-white/20 active:bg-white/30 text-white rounded-full py-2 px-3 sm:px-4 flex items-center text-xs sm:text-sm transition-all touch-target"
-        @click="$emit('showMusicSearch')"
-      >
-        <i class="fa-solid fa-music mr-1 sm:mr-2" />
-        <span class="hidden sm:inline">点歌台</span>
-        <span class="sm:hidden">点歌</span>
-      </button>
-
       <!-- 分享 -->
       <button
         class="bg-blue-500/20 hover:bg-blue-500/30 active:bg-blue-500/40 text-blue-400 rounded-full py-2 px-3 sm:px-4 flex items-center text-xs sm:text-sm transition-all touch-target"
@@ -100,7 +90,6 @@ const props = defineProps<Props>()
 
 // 定义 emits
 defineEmits<{
-  showMusicSearch: []
   shareRoom: []
   showHelp: []
   toggleImmersive: []


### PR DESCRIPTION
Relocate the music search button to the playlist section for improved accessibility and user experience. Update the event emission for showing the music search modal accordingly.