### PR TITLE
fix: make PWA update modal visible in all interfaces

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,13 @@
     class="bg-gradient-to-br from-dark to-gray-900 text-light h-screen-mobile font-inter overflow-hidden relative touch-none"
     style="scrollbar-width: none; -ms-overflow-style: none;"
   >
+    <!-- PWA 更新提示 -->
+    <PWAUpdateModal
+      :show-update-modal="showUpdateModal"
+      @update-app="handleUpdateApp"
+      @dismiss-update="handleDismissUpdate"
+    />
+
     <!-- 确认加入房间模态框 -->
     <JoinRoomModal
       :show="showJoinRoomConfirm"
@@ -203,12 +210,6 @@
 
       <!-- 通知容器 -->
       <NotificationContainer />
-      <!-- PWA 更新提示 -->
-      <PWAUpdateModal
-        :show-update-modal="showUpdateModal"
-        @update-app="handleUpdateApp"
-        @dismiss-update="handleDismissUpdate"
-      />
 
       <!-- WebSocket 连接配置显示（开发环境） -->
       <div v-if="isDevelopment && !isImmersiveMode" class="fixed bottom-4 right-4 z-40">

--- a/src/components/PWAUpdateModal.vue
+++ b/src/components/PWAUpdateModal.vue
@@ -5,7 +5,7 @@
     theme="primary"
     title="应用更新"
     header-icon="fa-solid fa-sync"
-    :z-index="50"
+    :z-index="150"
     :show-header="true"
     :allow-backdrop-close="!isUpdating"
     @close="dismissUpdate"


### PR DESCRIPTION
## Summary
  - Move PWA update modal to app root level so it displays in all interfaces
  - Increase z-index from 50 to 150 to ensure it appears above other modals like room selection

  ## Test plan
  - Verified update modal now shows in room selection interface
  - Confirmed modal appears above other interface elements
  - Tested functionality works as expected in different app states

  Fixes the issue where users couldn't see PWA update notifications when in the room selection interface.

  🤖 Generated with [Claude Code](https://claude.ai/code)